### PR TITLE
HPCC-19457 Fix skew in ordered keyed join tests

### DIFF
--- a/PerformanceTesting/ecl/07aa_keyedjoin123.ecl
+++ b/PerformanceTesting/ecl/07aa_keyedjoin123.ecl
@@ -10,7 +10,7 @@ import suite.perform.files;
 import suite.perform.util;
 
 unsigned scale := IF(config.smokeTest, 0x10000, 0x100);
-ds := files.generateSimpleScaled(0, scale);
+ds := DATASET(config.simpleRecordCount DIV scale, format.createSimple(COUNTER * scale), DISTRIBUTED);
 
 j := JOIN(ds, files.manyIndex123,
             RIGHT.id1a = util.byte(LEFT.id1, 0) AND 

--- a/PerformanceTesting/ecl/07cc_keyedjoinlimit_no3.ecl
+++ b/PerformanceTesting/ecl/07cc_keyedjoinlimit_no3.ecl
@@ -8,7 +8,7 @@ import suite.perform.files;
 import suite.perform.util;
 
 unsigned scale := IF(config.smokeTest, 0x10000, 0x100);
-ds := files.generateSimpleScaled(0, scale);
+ds := DATASET(config.simpleRecordCount DIV scale, format.createSimple(COUNTER * scale), DISTRIBUTED);
 
 j := JOIN(ds, files.manyIndex123,
             RIGHT.id1a = util.byte(LEFT.id1, 0) AND 

--- a/PerformanceTesting/ecl/07dc_keyedjoinlimit_hit3.ecl
+++ b/PerformanceTesting/ecl/07dc_keyedjoinlimit_hit3.ecl
@@ -8,7 +8,7 @@ import suite.perform.files;
 import suite.perform.util;
 
 unsigned scale := IF(config.smokeTest, 0x10000, 0x100);
-ds := files.generateSimpleScaled(0, scale);
+ds := DATASET(config.simpleRecordCount DIV scale, format.createSimple(1 + ((COUNTER-1) * scale)), DISTRIBUTED);
 
 j := JOIN(ds, files.manyIndex123,
             RIGHT.id1a = util.byte(LEFT.id1, 0) AND 
@@ -21,4 +21,4 @@ j := JOIN(ds, files.manyIndex123,
             LIMIT(255, SKIP)); 
 cnt := COUNT(NOFOLD(j));
 
-OUTPUT(cnt = 255*255);  // Only the items [1..255] match
+OUTPUT(cnt = 255);  // Only the items [1..255] match

--- a/PerformanceTesting/ecl/07ec_keyedjoinkeylimit_hit3.ecl
+++ b/PerformanceTesting/ecl/07ec_keyedjoinkeylimit_hit3.ecl
@@ -8,7 +8,7 @@ import suite.perform.files;
 import suite.perform.util;
 
 unsigned scale := IF(config.smokeTest, 0x10000, 0x100);
-ds := files.generateSimpleScaled(0, scale);
+ds := DATASET(config.simpleRecordCount DIV scale, format.createSimple(1 + ((COUNTER-1) * scale)), DISTRIBUTED);
 
 j := JOIN(ds, files.manyIndex123,
             RIGHT.id1a = util.byte(LEFT.id1, 0) AND 
@@ -20,4 +20,4 @@ j := JOIN(ds, files.manyIndex123,
             RIGHT.id1g = util.byte(LEFT.id1, 6), LIMIT(255, SKIP, COUNT)); 
 cnt := COUNT(NOFOLD(j));
 
-OUTPUT(cnt = 255*255);  // Only the items [1..255] match
+OUTPUT(cnt = 255);  // Only the items [1..255] match

--- a/PerformanceTesting/ecl/07fc_keyedjoinfaillimit_hit3.ecl
+++ b/PerformanceTesting/ecl/07fc_keyedjoinfaillimit_hit3.ecl
@@ -8,7 +8,7 @@ import suite.perform.files;
 import suite.perform.util;
 
 unsigned scale := IF(config.smokeTest, 0x10000, 0x100);
-ds := files.generateSimpleScaled(0, scale);
+ds := DATASET(config.simpleRecordCount DIV scale, format.createSimple(1 + ((COUNTER-1) * scale)), DISTRIBUTED);
 
 j := JOIN(ds, files.manyIndex123,
             RIGHT.id1a = util.byte(LEFT.id1, 0) AND 
@@ -21,4 +21,5 @@ j := JOIN(ds, files.manyIndex123,
             TRANSFORM(LEFT), LIMIT(255, TRANSFORM(format.simpleRec, SELF := []))); 
 cnt := COUNT(NOFOLD(j));
 
-OUTPUT(cnt = 255*255 + (config.simpleRecordCount DIV scale) - 255);
+// 255 matches from 1st record, the rest return 1 limit transform rec. each
+OUTPUT(cnt = 255 + (config.simpleRecordCount DIV scale)-1);


### PR DESCRIPTION
The ordered keyed join tests were unintentionally very skewed.

Signed-off-by: Jake Smith <jake.smith@lexisnexis.com>