### PR TITLE
HPCC-19509 Fix keyed join 07cc test.

### DIFF
--- a/PerformanceTesting/ecl/07aa_keyedjoin123.ecl
+++ b/PerformanceTesting/ecl/07aa_keyedjoin123.ecl
@@ -10,7 +10,7 @@ import suite.perform.files;
 import suite.perform.util;
 
 unsigned scale := IF(config.smokeTest, 0x10000, 0x100);
-ds := DATASET(config.simpleRecordCount DIV scale, format.createSimple(COUNTER * scale), DISTRIBUTED);
+ds := DATASET(config.simpleRecordCount DIV scale, format.createSimple(1 + (COUNTER-1) * scale), DISTRIBUTED);
 
 j := JOIN(ds, files.manyIndex123,
             RIGHT.id1a = util.byte(LEFT.id1, 0) AND 

--- a/PerformanceTesting/ecl/07cc_keyedjoinlimit_no3.ecl
+++ b/PerformanceTesting/ecl/07cc_keyedjoinlimit_no3.ecl
@@ -8,7 +8,7 @@ import suite.perform.files;
 import suite.perform.util;
 
 unsigned scale := IF(config.smokeTest, 0x10000, 0x100);
-ds := DATASET(config.simpleRecordCount DIV scale, format.createSimple(COUNTER * scale), DISTRIBUTED);
+ds := DATASET(config.simpleRecordCount DIV scale, format.createSimple(1 + (COUNTER-1) * scale), DISTRIBUTED);
 
 j := JOIN(ds, files.manyIndex123,
             RIGHT.id1a = util.byte(LEFT.id1, 0) AND 
@@ -20,4 +20,4 @@ j := JOIN(ds, files.manyIndex123,
             RIGHT.id1g = util.byte(LEFT.id1, 6), LIMIT(256)); 
 cnt := COUNT(NOFOLD(j));
 
-OUTPUT(cnt = (config.simpleRecordCount DIV scale) * 256 - 255);  // -255 because [1..255] only match 255 entries
+OUTPUT(cnt = (config.simpleRecordCount DIV scale) * 256 - 1);  // -1 because 1st record only matches 255 entries.


### PR DESCRIPTION
The scaled LHS introduced by HPCC-19457 could produce a mismatched
count. Ensure the expected count correct by adjusting the lhs
keys in the scaled count.

Signed-off-by: Jake Smith <jake.smith@lexisnexis.com>